### PR TITLE
Add a missing quote

### DIFF
--- a/docs/templating-guide/index.md
+++ b/docs/templating-guide/index.md
@@ -75,7 +75,7 @@ An example of the usage:
 requests:
   - method: GET
     path:
-      - "{{BaseURL}}/login.php
+      - "{{BaseURL}}/login.php"
     redirects: true
     max-redirects: 3
 ```


### PR DESCRIPTION
A quote was missing in one of the example of the templating guide.