### PR TITLE
Fix Broken links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Nuclei - Community Powered Vulnerability Scanner
 site_description: Learn how to use Nuclei engine to write your own custom security checks with very simple and easy to use templating syntax.
-repo_url: https://github.com/projectdiscovery/nuclei/
+site_url: https://nuclei.projectdiscovery.io
+repo_url: https://github.com/projectdiscovery/nuclei-docs/
 # Copyright
 copyright: Copyright &copy; 2021 ProjectDiscovery, Inc.
 
@@ -94,7 +95,6 @@ nav:
   - Getting Started:
       - Index: nuclei/get-started.md
       - Features: nuclei/get-started/#nuclei-features
-      - Uses: nuclei/get-started/#using-nuclei
       - Contribution: nuclei/get-started/#code-contribution
       - License: nuclei/get-started/#license
 
@@ -103,11 +103,11 @@ nav:
       - Template Details: templating-guide/#template-details
       - HTTP: 
           - Base requests: templating-guide/protocols/http.md
-          - Raw requests: templating-guide/protocols/http.html#raw-http-requests
-          - HTTP fuzzing: templating-guide/protocols/http.html#http-fuzzing
-          - Unsafe HTTP requests: templating-guide/protocols/http.html#unsafe-http-requests
-          - Advance Fuzzing: templating-guide/protocols/http.html#advance-fuzzing
-          - Offline HTTP: templating-guide/protocols/http.html#advance-fuzzing
+          - Raw requests: templating-guide/protocols/http/#raw-http-requests
+          - HTTP fuzzing: templating-guide/protocols/http/#http-fuzzing
+          - Unsafe HTTP requests: templating-guide/protocols/http/#unsafe-http-requests
+          - Advance Fuzzing: templating-guide/protocols/http/#advance-fuzzing
+          - Offline HTTP: templating-guide/protocols/http/#advance-fuzzing
       - Headless: templating-guide/protocols/headless.md
       - Network: templating-guide/protocols/network.md
       - DNS: templating-guide/protocols/dns.md


### PR DESCRIPTION
Fixes:

- Nav links on Getting Started page, example: https://nuclei.projectdiscovery.io/nuclei/get-started/#nuclei-features
- Edit button on every page because it points to https://github.com/projectdiscovery/nuclei