### PR TITLE
Update nuclei -h output info.

### DIFF
--- a/docs/nuclei/get-started.md
+++ b/docs/nuclei/get-started.md
@@ -138,7 +138,7 @@ This will display help for the tool. Here are all the switches it supports.
     -timeout int                           Time to wait in seconds before timeout (default 5)
     -tl                                    List available templates
     -trace-log string                      File to write sent requests trace log
-    -ud, -update-directory string          Directory storing nuclei-templates (default /home/kali/nuclei-templates)
+    -ud, -update-directory string          Directory storing nuclei-templates (default /root/nuclei-templates)
     -ut, -update-templates                 Download / updates nuclei community templates
     -v, -verbose                           Show verbose output
     -version                               Show version of nuclei

--- a/docs/nuclei/get-started.md
+++ b/docs/nuclei/get-started.md
@@ -90,7 +90,6 @@ This will display help for the tool. Here are all the switches it supports.
     -bs, -bulk-size int                    Maximum Number of hosts analyzed in parallel per template (default 25)
     -c, -concurrency int                   Maximum Number of templates executed in parallel (default 10)
     -config string                         Nuclei configuration file
-    -de, -disk-export string               Directory on disk to export reports in markdown to
     -debug                                 Debugging request and responses
     -debug-req                             Debugging request
     -debug-resp                            Debugging response
@@ -103,9 +102,10 @@ This will display help for the tool. Here are all the switches it supports.
     -interactions-cooldown-period int      Extra time for interaction polling before exiting (default 5)
     -interactions-eviction int             Number of seconds to wait before evicting requests from cache (default 60)
     -interactions-poll-duration int        Number of seconds before each interaction poll request (default 5)
-    -interactsh-url string                 Interactsh Server URL (default https://interact.sh)
+    -interactsh-url string                 Self Hosted Interactsh Server URL (default https://interact.sh)
     -json                                  Write json output to files
     -l, -list string                       List of URLs to run templates on
+    -me, -markdown-export string           Directory to export results in markdown format
     -metrics                               Expose nuclei metrics on a port
     -metrics-port int                      Port to expose nuclei metrics on (default 9092)
     -nc, -no-color                         Disable colors in output
@@ -124,6 +124,7 @@ This will display help for the tool. Here are all the switches it supports.
     -rc, -report-config string             Nuclei Reporting Module configuration file
     -rdb, -report-db string                Local Nuclei Reporting Database (Always use this to persistent report data)
     -retries int                           Number of times to retry a failed request (default 1)
+    -se, -sarif-export string              File to export results in sarif format
     -show-browser                          Show the browser on the screen
     -si, -stats-interval int               Number of seconds between each stats line (default 5)
     -silent                                Show only results in output
@@ -137,7 +138,7 @@ This will display help for the tool. Here are all the switches it supports.
     -timeout int                           Time to wait in seconds before timeout (default 5)
     -tl                                    List available templates
     -trace-log string                      File to write sent requests trace log
-    -ud, -update-directory string          Directory storing nuclei-templates (default /root/nuclei-templates)
+    -ud, -update-directory string          Directory storing nuclei-templates (default /home/kali/nuclei-templates)
     -ut, -update-templates                 Download / updates nuclei community templates
     -v, -verbose                           Show verbose output
     -version                               Show version of nuclei


### PR DESCRIPTION
After nuclei version was updated, the flag was adjusted, so updated to -h output of the v2.3.8 version.