### PR TITLE
fix clusterbomb example in templating-guide

### DIFF
--- a/docs/templating-guide/protocols/http.md
+++ b/docs/templating-guide/protocols/http.md
@@ -268,7 +268,7 @@ requests:
     payloads:
       path: helpers/wordlists/prams.txt
       header: helpers/wordlists/header.txt
-    attack: pitchfork # Defining HTTP fuzz attack type
+    attack: clusterbomb # Defining HTTP fuzz attack type
 ```
 
 #### Unsafe HTTP Requests


### PR DESCRIPTION
The example description talked about clusterbomb but the example used pitchfork attack type