### PR TITLE
metadata template field and uncover options

### DIFF
--- a/docs/nuclei/get-started.md
+++ b/docs/nuclei/get-started.md
@@ -198,7 +198,7 @@ INTERACTSH:
 UNCOVER:
    -uc, -uncover                  enable uncover engine
    -uq, -uncover-query string[]   uncover search query
-   -ue, -uncover-engine string[]  uncover search engine (shodan,shodan-idb,fofa,censys,quake,hunter,zoomeye,netlas) (default shodan)
+   -ue, -uncover-engine string[]  uncover search engine (shodan,shodan-idb,fofa,censys,quake,hunter,zoomeye,netlas,criminalip) (default shodan)
    -uf, -uncover-field string     uncover fields to return (ip,port,host) (default "ip:port")
    -ul, -uncover-limit int        uncover results to return (default 100)
    -ucd, -uncover-delay int       delay between uncover query requests in seconds (0 to disable) (default 1)
@@ -476,7 +476,7 @@ nuclei -h uncover
 UNCOVER:
    -uc, -uncover                  enable uncover engine
    -uq, -uncover-query string[]   uncover search query
-   -ue, -uncover-engine string[]  uncover search engine (shodan,shodan-idb,fofa,censys,quake,hunter,zoomeye) (default shodan)
+   -ue, -uncover-engine string[]  uncover search engine (shodan,shodan-idb,fofa,censys,quake,hunter,zoomeye,netlas,criminalip) (default shodan)
    -uf, -uncover-field string     uncover fields to return (ip,port,host) (default "ip:port")
    -ul, -uncover-limit int        uncover results to return (default 100)
    -ucd, -uncover-delay int       delay between uncover query requests in seconds (0 to disable) (default 1)

--- a/docs/templating-guide/index.md
+++ b/docs/templating-guide/index.md
@@ -22,7 +22,7 @@ ID must not contain spaces. This is done to allow easier output parsing.
 
 ### Information
 
-Next important piece of information about a template is the **info** block. Info block provides **name**, **author**, **severity**, **description**, **reference** and **tags**. It also contains **severity** field which indicates the severity of the template, **info** block also supports dynamic fields, so one can define N number of `key: value` blocks to provide more useful information about the template. **reference** is another popular tag to define external reference links for the template.
+Next important piece of information about a template is the **info** block. Info block provides **name**, **author**, **severity**, **description**, **reference**, **tags** and `metadata`. It also contains **severity** field which indicates the severity of the template, **info** block also supports dynamic fields, so one can define N number of `key: value` blocks to provide more useful information about the template. **reference** is another popular tag to define external reference links for the template.
 
 Another useful tag to always add in `info` block is **tags**. This allows you to set some custom tags to a template, depending on the purpose like `cve`, `rce` etc. This allows nuclei to identify templates with your input tags and only run them.
 
@@ -45,4 +45,19 @@ Each template file can contain multiple requests to be made. The template is ite
 
 The best part of this is you can simply share your crafted template with your teammates, triage/security team to replicate the issue on the other side with ease.
 
+#### Metadata
 
+It's possible to add metadata nodes, for example, to integrates with [uncover](https://github.com/projectdiscovery/uncover) (cf. [Uncover Integration](https://nuclei.projectdiscovery.io/nuclei/get-started/#uncover-integration)).
+
+The metadata nodes are crafted this way: `<engine>-query: '<query>'` where:
+
+- `<engine>` is the search engine, equivalent of the value of the `-ue` option of nuclei or the `-e` option of uncover
+- `<query>` is the search query, equivalent of the value of the `-uq` option of nuclei or the `-q` option of uncover
+
+For example for Shodan:
+
+```
+info:
+  metadata:
+    shodan-query: 'vuln:CVE-2021-26855'
+```


### PR DESCRIPTION
fix https://github.com/projectdiscovery/nuclei-templates/discussions/6481

- clarify the possible values of `metadata` node in the template especially the query for uncover. maybe adding what `validated` is for and maybe other undocumented values
- update uncover engine options