### PR TITLE
Fix issue with description of modes

### DIFF
--- a/docs/templating-guide/protocols/http-fuzzing.md
+++ b/docs/templating-guide/protocols/http-fuzzing.md
@@ -34,8 +34,8 @@ fuzzing:
 
 Mode specifies the mode in which to perform the replacements. Available modes are - 
 
-1. **multiple** (`default`) - replace one value at a time
-2. **single** - replace all values at once
+1. **multiple** (`default`) - replace all values at once
+2. **single** - replace one value at a time
 
 ```yaml
 fuzzing:


### PR DESCRIPTION
The defaults PR (#99) moved multiple as the mode to the top as it is the default, but failed to swap the description of single vs. multiple. This corrects that.