### PR TITLE
Add intro to Getting Started

### DIFF
--- a/docs/nuclei/get-started.md
+++ b/docs/nuclei/get-started.md
@@ -1,3 +1,20 @@
+## Automate Network Vulnerability Scans with **Nuclei**
+
+Nuclei can help you ensure the security of complex networks. With vulnerability scans,
+Nuclei can identify security issues on your network. Once configured, Nuclei can
+provide detailed information on each vulnerability, including:
+
+- Severity
+- Impact
+- Recommended remediation
+
+Once you've set up templates, you can automate scans of your systems with every change
+to your network, and with every discovery of new security issues.
+
+In this Getting Started guide, we describe how you can set up Nuclei to automate
+vulnerability scans on a relatively simple network. You can then use our [Templating
+Guide](https://nuclei.projectdiscovery.io/templating-guide/) to customize Nuclei for your networks.
+
 ## **Nuclei** Features
 
 


### PR DESCRIPTION
Getting Started guides are somewhat unique for product documentation. They serve as a transition between marketing copy and specific use cases.

As I'm not (yet) an expert on Nuclei, I've made some assumptions on the capabilities. If I'm wrong, that's OK.

Best practice (in my experience): a Getting Started guide focuses on a relatively straightforward and short use case. This PR only adds an introduction. It does _not_ address any of the suggestions I have for this and other Nuclei docs.